### PR TITLE
use env vars for db connection parameters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,29 +16,36 @@ const (
 
 // Env holds the current environment
 var (
-	Env          string
-	Port         string
-	DBHost       string
-	DBDriver     string
-	DBName       string
-	DBDataSource string
+	Env      string
+	Port     string
+	DBDriver string
+	DBHost   string
+	DBPort   string
+	DBUser   string
+	DBPass   string
+	DBName   string
+	DBDsn    string
 )
 
 // Initialize ...
 func Initialize() {
 	GetAllEnv()
+	DBDsn = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
+		DBUser, DBPass, DBHost, DBPort, DBName)
+
 }
 
 // GetAllEnv should get all the env configs required for the app.
 func GetAllEnv() {
 	// API Configs
 	mustEnv("ENV", &Env, EnvDev)
-	mustEnv("DB_HOST", &DBHost, "localhost")
 	mustEnv("PORT", &Port, "8080")
 	mustEnv("DB_DRIVER", &DBDriver, "mysql")
+	mustEnv("DB_HOST", &DBHost, "localhost")
+	mustEnv("DB_PORT", &DBPort, "3306")
+	mustEnv("DB_USER", &DBUser, "root")
+	mustEnv("DB_PASS", &DBPass, "SecretPassword")
 	mustEnv("DB_NAME", &DBName, "slotracker_dev")
-	mustEnv("DB_DATASOURCE", &DBDataSource,
-		"root:SecretPassword@tcp(127.0.0.1:3306)/slotracker_dev?charset=utf8mb4&parseTime=True&loc=Local")
 }
 
 // mustEnv get the env variable with the name 'key' and store it in 'value'

--- a/store/store.go
+++ b/store/store.go
@@ -18,8 +18,7 @@ var dbConn *gorm.DB
 func Init() {
 
 	// Connect to mysql using sql driver and create a database
-	dbConnectionString := fmt.Sprintf("root:SecretPassword@tcp(%s:3306)/", config.DBHost)
-	db, err := sql.Open("mysql", dbConnectionString)
+	db, err := sql.Open(config.DBDriver, config.DBDsn)
 	if err != nil {
 		panic(err)
 	}
@@ -27,8 +26,7 @@ func Init() {
 	db.Close()
 
 	// Connect to newrely created database using gorm
-	dbConnectionString = fmt.Sprintf("root:SecretPassword@tcp(%s:3306)/slotracker_dev?charset=utf8mb4&parseTime=True&loc=Local", config.DBHost)
-	gormDb, err := gorm.Open(mysql.Open(dbConnectionString), &gorm.Config{})
+	gormDb, err := gorm.Open(mysql.Open(config.DBDsn), &gorm.Config{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# Use env vars for DB connection parameters. Solves #13 

## What does this pull do?
Update the config settings and store.go to read env vars for DB connection parameters, and formats the DB DSN accordingly. This still likely only works for mysql, but allows for deployment flexibility.

## What kind of changes do it do

Please delete options that are not relevant.

- [x] BUG ( change which fixes an issue )

## Need any DB Migrations?

- [ ] Yes
- [x] No

## How have you tested this

The code compiles and runs, and connects to a DB of my choosing:

```shell
8:11:20 ~/work/slo-tracker > DB_NAME=slotracker DB_USER=slotracker DB_PASS="slotracker 123" go run main.go
ENV env variable not set, using default value.
PORT env variable not set, using default value.
DB_DRIVER env variable not set, using default value.
DB_HOST env variable not set, using default value.
DB_PORT env variable not set, using default value.
Creating the slo table now!
2021-09-11T08:12:39.995-0400	INFO	slo-tracker/main.go:56	Starting slo-tracker:0.0.1 on port :8080

Creating the first record!
Default SLO record got created
2021/09/11 08:13:42 "GET http://localhost:8080/ HTTP/1.1" from 127.0.0.1:35626 - 200 93B in 700.203µs
2021/09/11 08:13:51 "GET http://localhost:8080/ HTTP/1.1" from 127.0.0.1:35628 - 200 93B in 856.877µs
```

- [x] Yes
- [ ] No

## This change requires a documentation update?

- [x] Yes
- [ ] No

There is no documentation about this topic yet, currently it only works via docker-compose.

## Code Checklist

- [x] Build passed
- [x] My changes generate no new warnings
- [x] Manually Tested
- [x] Rebased with master/upto date with master

## TODO

 - [] Please break down the problem into TODO's

## Pre-Merge Checklist

- [ ] I have **Labeled** my PR
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or raised against changes to the concerned person ( please mention here )
- [ ] Any dependent changes have been merged and published
