### PR TITLE
fix db create bug

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -18,7 +18,8 @@ var dbConn *gorm.DB
 func Init() {
 
 	// Connect to mysql using sql driver and create a database
-	db, err := sql.Open(config.DBDriver, config.DBDsn)
+	tempDsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/", config.DBUser, config.DBPass, config.DBHost, config.DBPort)
+	db, err := sql.Open("mysql", tempDsn)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# [Description]
My previous PR #14 causes an issue when the DB does not exist,.

## What does this pull do?
The initial db connection where it tries to create the db will fail because the db does not exist. It is necessary to use a temp DSN here without specifying the DB name.

## What kind of changes do it do
Stops crashing if the db does not exist.

Please delete options that are not relevant.

- [x] BUG ( change which fixes an issue )

## Need any DB Migrations?

- [x] No

## How have you tested this
Deleted the temp db, re-ran docker-compose build && docker-compose up and the DB was created.

- [x] Yes

## This change requires a documentation update?

- [x] No

## Code Checklist

- [x] Build passed
- [x] My changes generate no new warnings
- [x] Manually Tested
- [x] Rebased with master/upto date with master

## TODO

 - [] Please break down the problem into TODO's

## Pre-Merge Checklist

- [ ] I have **Labeled** my PR
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation or raised against changes to the concerned person ( please mention here )
- [ ] Any dependent changes have been merged and published
