### PR TITLE
use multistage build to slim down backend container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# these don't end up in the final image, but no need to consider them in the build context
+*.md
+LICENSE
+images
+ui

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:latest AS builder
 
 LABEL app="slo-tracker"
 LABEL maintainer="roshan.aloor@gmail.com"
@@ -8,9 +8,16 @@ LABEL description="slo-tracker : Track your product SLO"
 WORKDIR /app
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/slo-tracker .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -o /app/slo-tracker .
 
+
+FROM scratch
+
+# we don't need these certs for local development, but we copy in case you want
+# to use this image for a production environment
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /app/slo-tracker /app/slo-tracker
 
 EXPOSE 8080
 
-CMD /app/slo-tracker
+CMD ["/app/slo-tracker"]


### PR DESCRIPTION
# [Description]

Use a multistage build to trim down about a GB from the final container

```
docker images | grep slo-tracker
slo-tracker-multistage                          latest            2e817d565dc5   14 minutes ago   8.44MB
slo-tracker-original                            latest            fb1f91e53890   2 hours ago      1.04GB
```

## What kind of changes do it do

Use a multistage build copying the final binary (that now has debugging and symbol tables stripped to make it even smaller) into a scratch container, which has basically nothing else in it. If you want to make it even smaller, you could remove the copying of the ssl certificates, but they don't really add that much size, and might be nice to have them if you ever need to run this with TLS in production.

Please delete options that are not relevant.

- [X] FEATURE ( change which adds functionality )

## Need any DB Migrations?

- [ ] Yes
- [X] No

## How have you tested this

`docker-compose up --build` and navigate to `localhost:3000`, then add some test SLOs

## This change requires a documentation update?

- [ ] Yes
- [X] No

## Code Checklist

- [X] Build passed
- [X] My changes generate no new warnings
- [X] Manually Tested
- [X] Rebased with master/upto date with master

## Pre-Merge Checklist

- [ ] I have **Labeled** my PR
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas